### PR TITLE
[FEAT] 게시글 상세보기 내 해시태그 추가

### DIFF
--- a/src/main/java/org/example/baba/controller/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/org/example/baba/controller/dto/response/PostDetailResponseDto.java
@@ -1,6 +1,7 @@
 package org.example.baba.controller.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.example.baba.domain.Post;
 import org.example.baba.domain.enums.SNSType;
@@ -21,19 +22,21 @@ public class PostDetailResponseDto {
   private SNSType type;
   private String title;
   private String content;
+  private List<String> hashtags;
   private int likeCount;
   private int shareCount;
   private int viewCount;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
-  public static PostDetailResponseDto from(Post post) {
+  public static PostDetailResponseDto from(Post post, List<String> postHashtags) {
     return PostDetailResponseDto.builder()
         .id(post.getId())
         .memberId(post.getMemberId())
         .type(post.getType())
         .title(post.getTitle())
         .content(post.getContent())
+        .hashtags(postHashtags)
         .likeCount(post.getLikeCount())
         .shareCount(post.getShareCount())
         .viewCount(post.getViewCount())

--- a/src/main/java/org/example/baba/domain/Post.java
+++ b/src/main/java/org/example/baba/domain/Post.java
@@ -1,5 +1,8 @@
 package org.example.baba.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.*;
 
 import org.example.baba.common.entity.BaseTimeEntity;
@@ -45,4 +48,7 @@ public class Post extends BaseTimeEntity {
   public void view() {
     this.viewCount++;
   }
+
+  @OneToMany(mappedBy = "post", orphanRemoval = true)
+  private List<PostHashTagMap> postHashTags = new ArrayList<>();
 }

--- a/src/main/java/org/example/baba/exception/exceptionType/PostExceptionType.java
+++ b/src/main/java/org/example/baba/exception/exceptionType/PostExceptionType.java
@@ -20,11 +20,11 @@ public enum PostExceptionType implements ExceptionType {
 
   @Override
   public HttpStatus status() {
-    return null;
+    return this.status;
   }
 
   @Override
   public String message() {
-    return null;
+    return this.message;
   }
 }

--- a/src/main/java/org/example/baba/repository/PostRepository.java
+++ b/src/main/java/org/example/baba/repository/PostRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
   Optional<Post> findByIdAndType(Long postId, SNSType type);
+
+  Optional<Post> findById(Long postId);
 }

--- a/src/main/java/org/example/baba/service/PostService.java
+++ b/src/main/java/org/example/baba/service/PostService.java
@@ -99,7 +99,6 @@ public class PostService {
             .orElseThrow(() -> new CustomException(PostExceptionType.NOT_FOUND_POST));
 
     post.view();
-    postRepository.save(post);
     return PostDetailResponseDto.from(post);
   }
 }

--- a/src/main/java/org/example/baba/service/PostService.java
+++ b/src/main/java/org/example/baba/service/PostService.java
@@ -1,7 +1,9 @@
 package org.example.baba.service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.example.baba.controller.dto.response.PostDetailResponseDto;
 import org.example.baba.domain.Post;
@@ -98,7 +100,12 @@ public class PostService {
             .findById(postId)
             .orElseThrow(() -> new CustomException(PostExceptionType.NOT_FOUND_POST));
 
+    List<String> hashtags =
+        post.getPostHashTags().stream()
+            .map(postHashTagMap -> postHashTagMap.getHashtag().getTagName())
+            .collect(Collectors.toList());
+
     post.view();
-    return PostDetailResponseDto.from(post);
+    return PostDetailResponseDto.from(post, hashtags);
   }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -3,22 +3,28 @@ INSERT INTO MEMBER (MEMBER_ID, EMAIL, MEMBER_NAME, PASSWORD, ROLE) VALUES
 (2, 'minjun@gmail.com', '김민준', '{noop}1234', 'USER'),
 (3, 'alice@example.com', '엘리스', '{noop}1234', 'ADMIN');
 
-INSERT INTO POST (ID, CONTENT, LIKE_COUNT, SHARE_COUNT, TITLE, TYPE, MEMBER_ID, VIEW_COUNT) VALUES
-(1, '와, 여기가 미국이구나!!', 10, 2, '미국 여행기!', 'INSTAGRAM', 1, 150),
-(2, '미국 햄버거 짠데 맛있네? ㅋㅋ', 25, 5, '미국 햄버거', 'INSTAGRAM', 1, 230),
-(3, '여기 카페 에스프레소 굿굿', 15, 3, '에스프레소', 'TWITTER', 2, 180),
-(4, '오운완 !!', 8, 1, 'Daily Post', 'INSTAGRAM', 3, 120);
+INSERT INTO POST (ID, CONTENT, LIKE_COUNT, SHARE_COUNT, TITLE, TYPE, MEMBER_ID, VIEW_COUNT, CREATED_AT, UPDATED_AT) VALUES
+(1, '와, 여기가 미국이구나!!', 10, 2, '미국 여행기!', 'INSTAGRAM', 1, 150, '2024-08-10 10:20:00', '2024-08-10 10:20:00'),
+(2, '미국 햄버거 짠데 맛있네? ㅋㅋ', 25, 5, '미국 햄버거', 'INSTAGRAM', 1, 230, '2024-08-18 10:20:00', '2024-08-18 10:20:00'),
+(3, '여기 카페 에스프레소 굿굿', 15, 3, '에스프레소', 'TWITTER', 2, 180, '2024-08-22 10:20:00', '2024-08-22 10:20:00'),
+(4, '오운완 !!', 8, 1, 'Daily Post', 'INSTAGRAM', 3, 120, '2024-08-23 10:20:00', '2024-08-23 10:20:00'),
+(5, '오늘도 코드 리뷰 완료!', 30, 6, '코드 리뷰 완료', 'TWITTER', 1, 300, '2024-08-24 11:00:00', '2024-08-24 11:00:00'),
+(6, '새로운 개발 프로젝트 시작!', 50, 10, '개발 프로젝트', 'INSTAGRAM', 2, 400, '2024-08-25 14:30:00', '2024-08-25 14:30:00');
+
 
 INSERT INTO HASH_TAG (ID, TAG_NAME) VALUES
 (1, '여행'),
 (2, '맛집'),
 (3, '카페'),
 (4, '오운완'),
-(5, '코딩');
+(5, '코딩'),
+(6, '개발');
 
 INSERT INTO POST_HASH_TAG_MAP (ID, HASHTAG_ID, POST_ID) VALUES
 (1, 1, 1),
 (2, 2, 1),
 (3, 2, 2),
 (4, 3, 3),
-(5, 4, 4);
+(5, 4, 4),
+(6, 5, 5),
+(7, 6, 5);


### PR DESCRIPTION
## 📱 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #44 
## 📱 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
-Postman 예외처리 메세지를 위해 null값 반환이던 것을 수정하였습니다
-게시글 상세조회 시 해시태그가 같이 보입니다.
-더미데이터에 날짜값, 태그, 게시글을 추가하였습니다
## 📱 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![스크린샷 2024-08-23 224201](https://github.com/user-attachments/assets/9eb8e71d-4a05-40b1-b13a-8c24717128c1)

## 📱 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
Post 엔티티 내 연관 관계를 최대한 늘리고 싶지 않았으나.. 추가하게 되었습니다.
방법을 고민중에 있는데 더 나은 방법이 있는 거 같다면 맘껏 말해주세요.. !
