### PR TITLE
[FEAT] 가입승인 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/org/example/baba/common/config/RedisConfig.java
+++ b/src/main/java/org/example/baba/common/config/RedisConfig.java
@@ -5,8 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -20,17 +18,5 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, port);
-  }
-
-  // Redis 데이터의 직렬화 및 역직렬화와 CRUD 작업을 관리
-  @Bean
-  public RedisTemplate<String, Object> redisTemplate() {
-    // RedisConnectionFactory 와 연결
-    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(redisConnectionFactory());
-    redisTemplate.setEnableTransactionSupport(true);
-    redisTemplate.setKeySerializer(new StringRedisSerializer());
-    redisTemplate.setValueSerializer(new StringRedisSerializer());
-    return redisTemplate;
   }
 }

--- a/src/main/java/org/example/baba/controller/MemberController.java
+++ b/src/main/java/org/example/baba/controller/MemberController.java
@@ -20,8 +20,18 @@ public class MemberController {
 
   @PostMapping
   public ResponseEntity<String> registerRequest(@Valid @RequestBody RegisterDTO registerDTO) {
+    // DB에서 중복 검사
     memberService.isDuplicated(registerDTO);
+    // Redis에서 중복 검사
+    memberService.existInRedis(registerDTO);
+    // 가입승인 코드 전송
     memberService.sendApprovalCode(registerDTO);
     return ResponseEntity.ok("인증 코드가 발송되었습니다.");
+  }
+
+  @PostMapping("/confirm")
+  public ResponseEntity<String> registerConfirm(@RequestParam("code") String code) {
+
+    return null;
   }
 }

--- a/src/main/java/org/example/baba/controller/MemberController.java
+++ b/src/main/java/org/example/baba/controller/MemberController.java
@@ -18,6 +18,7 @@ public class MemberController {
 
   private final MemberService memberService;
 
+  // 가입승인 요청 및 임시 회원가입
   @PostMapping
   public ResponseEntity<String> registerRequest(@Valid @RequestBody RegisterDTO registerDTO) {
     // DB에서 중복 검사
@@ -29,8 +30,11 @@ public class MemberController {
     return ResponseEntity.ok("인증 코드가 발송되었습니다.");
   }
 
+  // 가입승인 코드 확인 및 정식 회원가입
   @PostMapping("/confirm")
-  public ResponseEntity<String> registerConfirm(@RequestParam("code") String code) {
-    return null;
+  public ResponseEntity<String> registerConfirm(@RequestParam("code") String approvalCode) {
+    // 가입승인 및 정식 회원가입
+    memberService.confirmApprovalCode(approvalCode);
+    return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/org/example/baba/controller/MemberController.java
+++ b/src/main/java/org/example/baba/controller/MemberController.java
@@ -21,7 +21,7 @@ public class MemberController {
   @PostMapping
   public ResponseEntity<String> registerRequest(@Valid @RequestBody RegisterDTO registerDTO) {
     // DB에서 중복 검사
-    memberService.isDuplicated(registerDTO);
+    memberService.existInDB(registerDTO);
     // Redis에서 중복 검사
     memberService.existInRedis(registerDTO);
     // 가입승인 코드 전송

--- a/src/main/java/org/example/baba/controller/MemberController.java
+++ b/src/main/java/org/example/baba/controller/MemberController.java
@@ -31,7 +31,6 @@ public class MemberController {
 
   @PostMapping("/confirm")
   public ResponseEntity<String> registerConfirm(@RequestParam("code") String code) {
-
     return null;
   }
 }

--- a/src/main/java/org/example/baba/controller/dto/request/RegisterDTO.java
+++ b/src/main/java/org/example/baba/controller/dto/request/RegisterDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 import org.example.baba.common.anotation.ValidPassword;
+import org.example.baba.domain.Register;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -30,19 +31,11 @@ public class RegisterDTO {
   @Email(message = "올바른 이메일 형식이 아닙니다.")
   String email;
 
-  public String toJson() {
-    try {
-      return objectMapper.writeValueAsString(this);
-    } catch (Exception e) {
-      throw new RuntimeException("RegisterDTO 의 toJson 오류", e);
-    }
-  }
-
-  public static RegisterDTO fromJson(String json) {
-    try {
-      return objectMapper.readValue(json, RegisterDTO.class);
-    } catch (Exception e) {
-      throw new RuntimeException("RegisterDTO 의 fromJson 오류", e);
-    }
+  public Register toEntity(String preFix) {
+    return Register.builder()
+        .email(preFix + this.email)
+        .memberName(this.memberName)
+        .password(this.password)
+        .build();
   }
 }

--- a/src/main/java/org/example/baba/domain/ApprovalCode.java
+++ b/src/main/java/org/example/baba/domain/ApprovalCode.java
@@ -2,8 +2,7 @@ package org.example.baba.domain;
 
 import java.io.Serializable;
 
-import jakarta.persistence.Id;
-
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 import lombok.*;

--- a/src/main/java/org/example/baba/domain/ApprovalCode.java
+++ b/src/main/java/org/example/baba/domain/ApprovalCode.java
@@ -12,6 +12,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 @RedisHash(value = "ApprovalCode", timeToLive = 600)
 public class ApprovalCode implements Serializable {
 

--- a/src/main/java/org/example/baba/domain/ApprovalCode.java
+++ b/src/main/java/org/example/baba/domain/ApprovalCode.java
@@ -13,6 +13,7 @@ import lombok.*;
 @Getter
 @EqualsAndHashCode
 @RedisHash(value = "ApprovalCode", timeToLive = 600)
+@ToString
 public class ApprovalCode implements Serializable {
 
   @Id String approvalKey;

--- a/src/main/java/org/example/baba/domain/ApprovalCode.java
+++ b/src/main/java/org/example/baba/domain/ApprovalCode.java
@@ -1,0 +1,21 @@
+package org.example.baba.domain;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Id;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@RedisHash(value = "ApprovalCode", timeToLive = 600)
+public class ApprovalCode implements Serializable {
+
+  @Id String approvalKey;
+
+  String email;
+}

--- a/src/main/java/org/example/baba/domain/Register.java
+++ b/src/main/java/org/example/baba/domain/Register.java
@@ -2,8 +2,7 @@ package org.example.baba.domain;
 
 import java.io.Serializable;
 
-import jakarta.persistence.Id;
-
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 import lombok.*;

--- a/src/main/java/org/example/baba/domain/Register.java
+++ b/src/main/java/org/example/baba/domain/Register.java
@@ -12,6 +12,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 @RedisHash(value = "Register", timeToLive = 7200)
 public class Register implements Serializable {
 

--- a/src/main/java/org/example/baba/domain/Register.java
+++ b/src/main/java/org/example/baba/domain/Register.java
@@ -1,0 +1,30 @@
+package org.example.baba.domain;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Id;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@RedisHash(value = "Register", timeToLive = 7200)
+public class Register implements Serializable {
+
+  @Id String email;
+
+  String memberName;
+  String password;
+
+  public Member toMember() {
+    return Member.builder()
+        .email(this.email)
+        .memberName(this.memberName)
+        .password(this.password)
+        .build();
+  }
+}

--- a/src/main/java/org/example/baba/domain/Register.java
+++ b/src/main/java/org/example/baba/domain/Register.java
@@ -2,6 +2,7 @@ package org.example.baba.domain;
 
 import java.io.Serializable;
 
+import org.example.baba.domain.enums.MemberRole;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
@@ -13,6 +14,7 @@ import lombok.*;
 @Getter
 @EqualsAndHashCode
 @RedisHash(value = "Register", timeToLive = 7200)
+@ToString
 public class Register implements Serializable {
 
   @Id String email;
@@ -20,11 +22,12 @@ public class Register implements Serializable {
   String memberName;
   String password;
 
-  public Member toMember() {
+  public Member toMember(int subStringIndex) {
     return Member.builder()
-        .email(this.email)
+        .email(this.email.substring(subStringIndex))
         .memberName(this.memberName)
         .password(this.password)
+        .memberRole(MemberRole.USER)
         .build();
   }
 }

--- a/src/main/java/org/example/baba/exception/exceptionType/RegisterExceptionType.java
+++ b/src/main/java/org/example/baba/exception/exceptionType/RegisterExceptionType.java
@@ -14,7 +14,20 @@ public enum RegisterExceptionType implements ExceptionType {
   // 중복된 계정
   DUPLICATED_MEMBER_NAME(HttpStatus.CONFLICT, "이미 사용 중인 계정입니다."),
   // 중복된 이메일
-  DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+  DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+  // Redis에 이미 저장된 사용자 정보가 있을 때
+  EMAIL_ALREADY_IN_PROGRESS(
+      HttpStatus.CONFLICT, "이 이메일로 가입이 진행중입니다. 이메일 인증을 완료하거나 일정 시간 후에 다시 시도해주세요."),
+
+  // 400 Bad Request
+  // 저장된 코드가 없을 때
+  NOT_FOUND_CODE(HttpStatus.BAD_REQUEST, "가입승인 코드가 유효하지 않습니다. 다시 시도해주세요."),
+  // 저장된 임시 데이터가 없을 때
+  NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST, "가입 가능 기간이 만료되었습니다. 다시 가입을 시도해주세요."),
+
+  // 500 Internal Server Error
+  // 코드 발송한 이메일과 임시 저장된 이메일 데이터 불일치
+  DATA_CONSISTENCY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다. 다시 시도해주세요.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/org/example/baba/repository/ApprovalCodeRepository.java
+++ b/src/main/java/org/example/baba/repository/ApprovalCodeRepository.java
@@ -1,0 +1,6 @@
+package org.example.baba.repository;
+
+import org.example.baba.domain.ApprovalCode;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ApprovalCodeRepository extends CrudRepository<ApprovalCode, String> {}

--- a/src/main/java/org/example/baba/repository/RegisterRepository.java
+++ b/src/main/java/org/example/baba/repository/RegisterRepository.java
@@ -1,0 +1,9 @@
+package org.example.baba.repository;
+
+import org.example.baba.domain.Register;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RegisterRepository extends CrudRepository<Register, String> {
+
+  boolean existsByMemberName(String memberName);
+}

--- a/src/main/java/org/example/baba/service/MemberService.java
+++ b/src/main/java/org/example/baba/service/MemberService.java
@@ -33,7 +33,7 @@ public class MemberService {
   public static final String APPROVALKEY_PREFIX = "approval:";
 
   // DB에서 중복 계정명, 중복 이메일 검사
-  public void isDuplicated(RegisterDTO registerDTO) {
+  public void existInDB(RegisterDTO registerDTO) {
     // 중복 계정명 검사
     boolean existByMemberName = memberRepository.existsByMemberName(registerDTO.getMemberName());
     // 중복 이메일 검사
@@ -78,7 +78,7 @@ public class MemberService {
   }
 
   // 가입승인 코드 생성
-  public static String generateRandomCode() {
+  public String generateRandomCode() {
     // StringBuilder 에 문자열 크기 지정해주며 생성
     StringBuilder randomCode = new StringBuilder(CHARACTERS.length());
     // 랜덤하게 CHARACTERS 의 인덱스를 뽑고 인덱스를 이용하여 연결된 문자열 생성

--- a/src/main/java/org/example/baba/service/MemberService.java
+++ b/src/main/java/org/example/baba/service/MemberService.java
@@ -1,16 +1,17 @@
 package org.example.baba.service;
 
 import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
 
 import org.example.baba.controller.dto.request.RegisterDTO;
+import org.example.baba.domain.ApprovalCode;
+import org.example.baba.domain.Register;
 import org.example.baba.exception.CustomException;
 import org.example.baba.exception.exceptionType.RegisterExceptionType;
+import org.example.baba.repository.ApprovalCodeRepository;
 import org.example.baba.repository.MemberRepository;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SessionCallback;
+import org.example.baba.repository.RegisterRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,71 +22,101 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberService {
 
   private final MemberRepository memberRepository;
-  private final RedisTemplate<String, Object> redisTemplate;
+  private final RegisterRepository registerRepository;
+  private final ApprovalCodeRepository approvalCodeRepository;
 
   private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   private static final int CODE_LENGTH = 6;
   private static final SecureRandom random = new SecureRandom();
 
-  // 중복 계정명, 중복 이메일 검사
+  public static final String MEMBERKEY_PREFIX = "temporary:";
+  public static final String APPROVALKEY_PREFIX = "approval:";
+
+  // DB에서 중복 계정명, 중복 이메일 검사
   public void isDuplicated(RegisterDTO registerDTO) {
     // 중복 계정명 검사
     boolean existByMemberName = memberRepository.existsByMemberName(registerDTO.getMemberName());
     // 중복 이메일 검사
-    boolean existByEmail = memberRepository.existsByEmail(registerDTO.getEmail());
+    boolean existByEmai = memberRepository.existsByEmail(registerDTO.getEmail());
 
     // 중복일 시 예외 발생
     if (existByMemberName) throw new CustomException(RegisterExceptionType.DUPLICATED_MEMBER_NAME);
-    if (existByEmail) throw new CustomException(RegisterExceptionType.DUPLICATED_EMAIL);
+    if (existByEmai) throw new CustomException(RegisterExceptionType.DUPLICATED_EMAIL);
+  }
+
+  // Redis에 임시저장된 사용자 정보가 있는지 검사
+  public void existInRedis(RegisterDTO registerDTO) {
+    // 중복 계정명 검사
+    boolean existByMemberName = registerRepository.existsByMemberName(registerDTO.getMemberName());
+    // 중복 이메일 검색
+    boolean existById = registerRepository.existsById(MEMBERKEY_PREFIX + registerDTO.getEmail());
+
+    // 중복일 시 예외 발생
+    if (existByMemberName) throw new CustomException(RegisterExceptionType.DUPLICATED_MEMBER_NAME);
+    if (existById) throw new CustomException(RegisterExceptionType.EMAIL_ALREADY_IN_PROGRESS);
   }
 
   // 임시 회원가입 및 가입승인 코드 발생
+  @Transactional
   public void sendApprovalCode(RegisterDTO registerDTO) {
-    // 임시 사용자 정보 키
-    String memberKey = "temporary:" + registerDTO.getEmail();
     // 가입승인 코드 생성
-    String code = generateRandomCode();
-    // 가입승인 코드 키
-    String approvalKey = "approval:" + code;
+    String randomCode = generateRandomCode();
+    // 가입승인 코드 엔티티 생성
+    ApprovalCode approvalCode =
+        ApprovalCode.builder()
+            .approvalKey(APPROVALKEY_PREFIX + randomCode)
+            .email(registerDTO.getEmail())
+            .build();
 
-    // 트랜잭션
-    // redis에 임시 사용자 정보 저장 및 가입승인 코드 저장
-    redisTemplate.execute(
-        new SessionCallback<Object>() {
-          @Override
-          public Object execute(RedisOperations operations) {
-            operations.multi();
-            try {
-              // redis에 임시 사용자 정보 저장
-              operations.opsForValue().set(memberKey, registerDTO.toJson());
-              // redis에 가입승인 코드 저장
-              operations.opsForValue().set(approvalKey, registerDTO.getEmail());
-
-              return operations.exec();
-            } catch (Exception e) {
-              operations.discard();
-              throw new RuntimeException("sendApprovalCode 메소드 redis 실행 실패", e);
-            }
-          }
-        });
-
-    // 만료시간 설정(TTL은 트랜잭션에 포함되지 않아서 따로 뺌)
-    redisTemplate.expire(memberKey, 2, TimeUnit.HOURS);
-    redisTemplate.expire(approvalKey, 10, TimeUnit.MINUTES);
+    // 사용자 정보 임시 저장
+    registerRepository.save(registerDTO.toEntity(MEMBERKEY_PREFIX));
+    // 가입승인 코드 저장
+    approvalCodeRepository.save(approvalCode);
 
     // 가입승인 코드를 포함한 이메일 전송
-    log.info("가입승인 코드 이메일 발송: {}, 가입승인 코드: {}", registerDTO.getEmail(), code);
+    log.info("가입승인 코드 이메일 발송: {}, 가입승인 코드: {}", registerDTO.getEmail(), randomCode);
   }
 
+  // 가입승인 코드 생성
   public static String generateRandomCode() {
     // StringBuilder 에 문자열 크기 지정해주며 생성
-    StringBuilder code = new StringBuilder(CHARACTERS.length());
-
+    StringBuilder randomCode = new StringBuilder(CHARACTERS.length());
     // 랜덤하게 CHARACTERS 의 인덱스를 뽑고 인덱스를 이용하여 연결된 문자열 생성
     for (int i = 0; i < CODE_LENGTH; i++) {
       int index = random.nextInt(CHARACTERS.length());
-      code.append(CHARACTERS.charAt(index));
+      randomCode.append(CHARACTERS.charAt(index));
     }
-    return code.toString();
+    return randomCode.toString();
+  }
+
+  // 가입승인 코드 검증 및 정식 회원가입
+  public void confirmApprovalCode(String approvalCode) {
+    // 가입승인 코드로 redis에 저장된 이메일 가져오기
+    ApprovalCode savedApproval =
+        approvalCodeRepository
+            .findById(APPROVALKEY_PREFIX + approvalCode)
+            .orElseThrow(() -> new CustomException(RegisterExceptionType.NOT_FOUND_CODE));
+    // 가입승인 코드와 함께 저장된 이메일을 키로 저장된 임시 사용자 정보 가져오기
+    Register savedRegister =
+        registerRepository
+            .findById(MEMBERKEY_PREFIX + savedApproval.getEmail())
+            .orElseThrow(() -> new CustomException(RegisterExceptionType.NOT_FOUND_MEMBER));
+
+    // 가입승인 코드와 함께 저장된 이메일
+    String approvalEmail = savedApproval.getEmail();
+    // 임시 저장 된 사용자 이메일
+    String registerEmail = savedRegister.getEmail();
+
+    // 가입승인 코드와 함께 저장된 이메일과 임시 사용자 정보의 이메일 비교 후 정식 회원가입
+    if (approvalEmail.equals(registerEmail)) {
+      memberRepository.save(savedRegister.toMember());
+    } else {
+      log.error(
+          "코드 발송한 이메일과 임시 저장된 이메일 불일치: code({}), savedEmail({}), Register Email({})",
+          approvalCode,
+          approvalEmail,
+          registerEmail);
+      throw new CustomException(RegisterExceptionType.DATA_CONSISTENCY_ERROR);
+    }
   }
 }

--- a/src/test/java/org/example/baba/common/RedisTest.java
+++ b/src/test/java/org/example/baba/common/RedisTest.java
@@ -3,28 +3,32 @@ package org.example.baba.common;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.example.baba.controller.dto.request.RegisterDTO;
+import org.example.baba.domain.ApprovalCode;
+import org.example.baba.domain.Register;
+import org.example.baba.repository.ApprovalCodeRepository;
+import org.example.baba.repository.RegisterRepository;
 import org.example.baba.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
 
 @SpringBootTest
 public class RedisTest {
 
-  @Autowired private RedisTemplate redisTemplate;
-  @Autowired private MemberService memberService;
+  @Autowired private RegisterRepository registerRepository;
+  @Autowired private ApprovalCodeRepository approvalCodeRepository;
 
   @BeforeEach
-  public void setup() {
-    redisTemplate.getConnectionFactory().getConnection();
+  public void setUp() {
+    registerRepository.deleteAll();
+    approvalCodeRepository.deleteAll();
   }
 
   @Test
   @DisplayName("Redis 데이터 저장, 조회 테스트")
-  public void sendApprovalCode() {
+  public void redisRepositoryTest() {
     // given
     RegisterDTO registerDTO =
         RegisterDTO.builder()
@@ -32,18 +36,23 @@ public class RedisTest {
             .password("Valid1234!")
             .email("sungmin@gmail.com")
             .build();
-    String memberKey = "temporary:" + registerDTO.getEmail();
-    String approvalKey = "approval:" + "123456";
+
+    String email = MemberService.MEMBERKEY_PREFIX + registerDTO.getEmail();
+    String approvalKey = MemberService.APPROVALKEY_PREFIX + "123456";
+
+    Register expectedRegister = registerDTO.toEntity(MemberService.MEMBERKEY_PREFIX);
+    ApprovalCode expectedApprovalCode =
+        ApprovalCode.builder().email(registerDTO.getEmail()).approvalKey(approvalKey).build();
 
     // when
-    memberService.sendApprovalCode(registerDTO);
+    registerRepository.save(expectedRegister);
+    approvalCodeRepository.save(expectedApprovalCode);
 
     // then
-    String stringRegisterDTO = (String) redisTemplate.opsForValue().get(memberKey);
-    RegisterDTO savedRegisterDTO = RegisterDTO.fromJson(stringRegisterDTO);
-    // String savedEmail = (String) redisTemplate.opsForValue().get(approvalKey);
+    Register savedRegister = registerRepository.findById(email).get();
+    ApprovalCode savedApprovalCode = approvalCodeRepository.findById(approvalKey).get();
 
-    assertEquals(registerDTO, savedRegisterDTO, "registerDTO 일치하지 않음");
-    // assertEquals(registerDTO.getEmail(), savedEmail, "email 일치하지 않음");
+    assertEquals(expectedRegister, savedRegister, "Register 일치하지 않음");
+    assertEquals(expectedApprovalCode, savedApprovalCode, "ApprovalCode 일치하지 않음");
   }
 }

--- a/src/test/java/org/example/baba/service/RegisterServiceTest.java
+++ b/src/test/java/org/example/baba/service/RegisterServiceTest.java
@@ -1,9 +1,12 @@
 package org.example.baba.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.example.baba.controller.dto.request.RegisterDTO;
+import org.example.baba.domain.ApprovalCode;
+import org.example.baba.domain.Register;
 import org.example.baba.exception.CustomException;
 import org.example.baba.exception.exceptionType.RegisterExceptionType;
 import org.example.baba.repository.ApprovalCodeRepository;
@@ -181,5 +184,37 @@ public class RegisterServiceTest {
 
     // then
     // 아무런 예외가 발생하지 않아야 함
+  }
+
+  // sendApprovalCode 메소드 테스트
+
+  @Test
+  public void sendApprovalCodeTest() {
+    // given
+    RegisterDTO registerDTO =
+        RegisterDTO.builder()
+            .memberName("김민지")
+            .password("Valid1234!")
+            .email("minji12@gmail.com")
+            .build();
+
+    String fixedCode = "123456";
+
+    MemberService spyMemberService = spy(memberService);
+    doReturn(fixedCode).when(spyMemberService).generateRandomCode();
+
+    Register expectedRegister = registerDTO.toEntity(MEMBERKEY_PREFIX);
+    ApprovalCode expectedApprovalCode =
+        ApprovalCode.builder()
+            .approvalKey(APPROVALKEY_PREFIX + fixedCode)
+            .email(registerDTO.getEmail())
+            .build();
+
+    // when
+    spyMemberService.sendApprovalCode(registerDTO);
+
+    // then
+    verify(registerRepository).save(eq(expectedRegister));
+    verify(approvalCodeRepository).save(eq(expectedApprovalCode));
   }
 }

--- a/src/test/java/org/example/baba/service/RegisterServiceTest.java
+++ b/src/test/java/org/example/baba/service/RegisterServiceTest.java
@@ -1,12 +1,14 @@
 package org.example.baba.service;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.example.baba.controller.dto.request.RegisterDTO;
 import org.example.baba.exception.CustomException;
 import org.example.baba.exception.exceptionType.RegisterExceptionType;
+import org.example.baba.repository.ApprovalCodeRepository;
 import org.example.baba.repository.MemberRepository;
+import org.example.baba.repository.RegisterRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,18 +18,25 @@ import org.mockito.MockitoAnnotations;
 
 public class RegisterServiceTest {
 
+  @Mock private RegisterRepository registerRepository;
   @Mock private MemberRepository memberRepository;
+  @Mock private ApprovalCodeRepository approvalCodeRepository;
 
   @InjectMocks private MemberService memberService;
+
+  public static final String MEMBERKEY_PREFIX = "temporary:";
+  public static final String APPROVALKEY_PREFIX = "approval:";
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
   }
 
+  // existInDB 메소드 테스트
+
   @Test
-  @DisplayName("중복된 계정명 실패 케이스")
-  public void duplicatedMemberName() {
+  @DisplayName("DB에서 중복된 계정명 실패 케이스")
+  public void duplicatedMemberNameInDB() {
 
     // given
     // RegisterDTO 생성
@@ -47,7 +56,7 @@ public class RegisterServiceTest {
         assertThrows(
             CustomException.class,
             () -> {
-              memberService.isDuplicated(registerDTO);
+              memberService.existInDB(registerDTO);
             });
 
     // 예외 메세지 확인
@@ -55,8 +64,8 @@ public class RegisterServiceTest {
   }
 
   @Test
-  @DisplayName("중복된 이메일 실패 케이스")
-  public void duplicatedEmail() {
+  @DisplayName("DB에서 중복된 이메일 실패 케이스")
+  public void duplicatedEmailInDB() {
 
     // given
     // RegisterDTO 생성
@@ -76,7 +85,7 @@ public class RegisterServiceTest {
         assertThrows(
             CustomException.class,
             () -> {
-              memberService.isDuplicated(registerDTO);
+              memberService.existInDB(registerDTO);
             });
 
     // 예외 메세지 확인
@@ -84,8 +93,8 @@ public class RegisterServiceTest {
   }
 
   @Test
-  @DisplayName("중복되지 않은 계정명, 이메일 성공 케이스")
-  public void noDuplicateNameAndEmail() {
+  @DisplayName("DB에서 중복되지 않은 계정명, 이메일 성공 케이스")
+  public void noDuplicateNameAndEmailInDB() {
     // given
     // RegisterDTO 생성
     RegisterDTO registerDTO =
@@ -100,7 +109,75 @@ public class RegisterServiceTest {
     when(memberRepository.existsByEmail("sungmin@gmail.com")).thenReturn(false);
 
     // when
-    memberService.isDuplicated(registerDTO);
+    memberService.existInDB(registerDTO);
+
+    // then
+    // 아무런 예외가 발생하지 않아야 함
+  }
+
+  // existInRedis 메소드 테스트
+
+  @Test
+  @DisplayName("Redis 에서 중복된 계정명 실패 케이스")
+  public void duplicatedMemberNameInRedis() {
+    // given
+    // RegisterDTO 생성
+    RegisterDTO registerDTO =
+        RegisterDTO.builder()
+            .memberName("김민지")
+            .password("Valid1234!")
+            .email("minji12@gmail.com")
+            .build();
+
+    when(registerRepository.existsByMemberName("김민지")).thenReturn(true);
+
+    // when & then
+    CustomException thrown =
+        assertThrows(CustomException.class, () -> memberService.existInRedis(registerDTO));
+    // 예외 메세지 확인
+    assertEquals(RegisterExceptionType.DUPLICATED_MEMBER_NAME.getMessage(), thrown.getMessage());
+  }
+
+  @Test
+  @DisplayName("Redis 에서 중복된 이메일 실패 케이스")
+  public void duplicatedEmailInRedis() {
+    // given
+    // RegisterDTO 생성
+    RegisterDTO registerDTO =
+        RegisterDTO.builder()
+            .memberName("김민지")
+            .password("Valid1234!")
+            .email("minji12@gmail.com")
+            .build();
+
+    when(registerRepository.existsById(MemberService.MEMBERKEY_PREFIX + "minji12@gmail.com"))
+        .thenReturn(true);
+
+    // when & then
+    CustomException thrown =
+        assertThrows(CustomException.class, () -> memberService.existInRedis(registerDTO));
+    // 예외 메세지 확인
+    assertEquals(RegisterExceptionType.EMAIL_ALREADY_IN_PROGRESS.getMessage(), thrown.getMessage());
+  }
+
+  @Test
+  @DisplayName("Redis 에서 중복되지 않은 계정명, 이메일 성공 케이스")
+  public void noDuplicateNameAndEmailInRedis() {
+    // given
+    // RegisterDTO 생성
+    RegisterDTO registerDTO =
+        RegisterDTO.builder()
+            .memberName("김민지")
+            .password("Valid1234!")
+            .email("minji12@gmail.com")
+            .build();
+
+    when(registerRepository.existsByMemberName("김민지")).thenReturn(true);
+    when(registerRepository.existsById(MemberService.MEMBERKEY_PREFIX + "minji12@gmail.com"))
+        .thenReturn(true);
+
+    // when
+    memberService.existInDB(registerDTO);
 
     // then
     // 아무런 예외가 발생하지 않아야 함

--- a/src/test/java/org/example/baba/service/RegisterServiceTest.java
+++ b/src/test/java/org/example/baba/service/RegisterServiceTest.java
@@ -27,9 +27,6 @@ public class RegisterServiceTest {
 
   @InjectMocks private MemberService memberService;
 
-  public static final String MEMBERKEY_PREFIX = "temporary:";
-  public static final String APPROVALKEY_PREFIX = "approval:";
-
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
@@ -203,10 +200,10 @@ public class RegisterServiceTest {
     MemberService spyMemberService = spy(memberService);
     doReturn(fixedCode).when(spyMemberService).generateRandomCode();
 
-    Register expectedRegister = registerDTO.toEntity(MEMBERKEY_PREFIX);
+    Register expectedRegister = registerDTO.toEntity(MemberService.MEMBERKEY_PREFIX);
     ApprovalCode expectedApprovalCode =
         ApprovalCode.builder()
-            .approvalKey(APPROVALKEY_PREFIX + fixedCode)
+            .approvalKey(MemberService.APPROVALKEY_PREFIX + fixedCode)
             .email(registerDTO.getEmail())
             .build();
 


### PR DESCRIPTION
## 📱 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #30
## 📱 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- [ ] Redis Repository 방식으로 변경
- [ ] 변경된 형식에 맞춰 회원가입 API 수정
- [ ] 중복 검증 메소드 테스트 완료
- [ ] RedisRepository 테스트 완료
- [ ] 가입승인 API 구현
- [ ] 가입승인 API 테스트 완료
## 📱 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 가입승인 요청 성공시

![가입승인 성공](https://github.com/user-attachments/assets/f6f7fb58-87ff-45fe-a73e-93aa91bc2b98)


- 가입승인 요청 실패(중복 계정명)

![가입승인 실패-중복계정](https://github.com/user-attachments/assets/415761b1-30cb-4547-a1be-71000ea752c9)


- 가입승인 요청 실패(중복 이메일)

![가입승인 실패-중복이메일](https://github.com/user-attachments/assets/a7203387-310f-41c1-bdbf-3d59315c4003)


- 가입승인 요청 실패(비밀번호 10자 미만)

![가입승인 실패-10자 미만](https://github.com/user-attachments/assets/5cec903a-676a-4818-8325-a8ad5f9d90d0)


- 가입승인 요청 실패(정규식 부적합)

![가입승인 실패-정규식 부적합](https://github.com/user-attachments/assets/aca58e9f-dea8-4e7c-bf40-8034410280bc)


- 가입승인 코드를 발급받고 대기중일 때 다시 회원가입 요청을 했을 시(가입 대기중)

![가입승인 대기중](https://github.com/user-attachments/assets/c5f4f835-6fd6-43d2-89a2-ccec61747b5f)


- 회원가입 성공

![회원가입 성공](https://github.com/user-attachments/assets/2b55c37d-1d5e-4fe6-a74f-06c1046da597)

## 📱 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
