### PR TITLE
[FEAT] default hashtag 구현

### DIFF
--- a/src/main/java/org/example/baba/common/config/SecurityConfig.java
+++ b/src/main/java/org/example/baba/common/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
                 authorize
                     .requestMatchers("/api/admin/**")
                     .hasRole("ADMIN")
+                    .requestMatchers("/api/stats/**")
+                    .hasAnyRole("USER", "ADMIN")
                     .anyRequest()
                     .permitAll())
         .sessionManagement(

--- a/src/main/java/org/example/baba/controller/StatisticsController.java
+++ b/src/main/java/org/example/baba/controller/StatisticsController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("/api/statistics")
+@RequestMapping("/api/stats")
 @RequiredArgsConstructor
 @Slf4j
 public class StatisticsController {

--- a/src/main/java/org/example/baba/exception/exceptionType/StatisticsExceptionType.java
+++ b/src/main/java/org/example/baba/exception/exceptionType/StatisticsExceptionType.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum StatisticsExceptionType implements ExceptionType {
   INVALID_DATE_RANGE_EXCEPTION(HttpStatus.BAD_REQUEST, "날짜의 범위가 올바르지 않습니다. 최대 30일까지 조회가 가능합니다."),
-  INVALID_HOUR_RANGE_EXCEPTION(HttpStatus.BAD_REQUEST, "날짜의 범위가 올바르지 않습니다. 최대 7일까지 조회가 가능합니다");
+  INVALID_HOUR_RANGE_EXCEPTION(HttpStatus.BAD_REQUEST, "날짜의 범위가 올바르지 않습니다. 최대 7일까지 조회가 가능합니다"),
+  INVALID_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "지원하는 타입이 아닙니다");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/org/example/baba/service/StatisticsService.java
+++ b/src/main/java/org/example/baba/service/StatisticsService.java
@@ -1,6 +1,7 @@
 package org.example.baba.service;
 
 import static org.example.baba.exception.exceptionType.AuthorizedExceptionType.*;
+import static org.example.baba.exception.exceptionType.StatisticsExceptionType.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -52,7 +53,7 @@ public class StatisticsService {
       posts = statisticsRepository.findPostsGroupedByHour(hashTag, startDateTime, endDateTime);
       result = groupByHour(posts, value, startDateTime, endDateTime);
     } else {
-      throw new IllegalArgumentException("Invalid type parameter");
+      throw new CustomException(INVALID_TYPE_EXCEPTION);
     }
 
     return result;

--- a/src/main/java/org/example/baba/service/StatisticsService.java
+++ b/src/main/java/org/example/baba/service/StatisticsService.java
@@ -62,7 +62,6 @@ public class StatisticsService {
     if (hashtag == null) {
       Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
       Long memberId = (long) authentication.getPrincipal();
-      log.info("memberId: {}", memberId);
       return memberRepository
           .findById(memberId)
           .orElseThrow(() -> new CustomException(UNAUTHENTICATED))

--- a/src/main/java/org/example/baba/service/StatisticsService.java
+++ b/src/main/java/org/example/baba/service/StatisticsService.java
@@ -11,8 +11,11 @@ import java.util.TreeMap;
 
 import org.example.baba.common.enums.StatisticsType;
 import org.example.baba.common.enums.StatisticsValue;
+import org.example.baba.exception.CustomException;
 import org.example.baba.repository.MemberRepository;
 import org.example.baba.repository.StatisticsRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,15 +59,15 @@ public class StatisticsService {
   }
 
   private String getOrDefaultEndDate(String hashtag) {
-    // if (hashtag == null) {
-    // Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    // Long memberId = Long.valueOf((String)authentication.getPrincipal());
-    // log.info("memberId: {}", memberId);
-    // return memberRepository
-    //     .findById(memberId)
-    //     .orElseThrow(() -> new CustomException(UNAUTHENTICATED))
-    //     .getMemberName();
-    // }
+    if (hashtag == null) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      Long memberId = (long) authentication.getPrincipal();
+      log.info("memberId: {}", memberId);
+      return memberRepository
+          .findById(memberId)
+          .orElseThrow(() -> new CustomException(UNAUTHENTICATED))
+          .getMemberName();
+    }
     return hashtag;
   }
 


### PR DESCRIPTION
## 📱 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #62

## 📱 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 인증객체 활용하여 default hashtag 구현
- CustomException 적용
- /api/stats에 ROLE(USER, ADMIN) 적용하여 토큰 없을 시에 API 호출 불가하도록 SecurityConfig 설정

## 📱 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- default hashtag 호출
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/80af75b1-60c2-4f68-9cbe-c9f45e2a3e09">
- 토큰 없이 요청 시
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/c172ab6e-cc37-4d13-9a7e-d582f8e182ab">


## 📱 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
