### PR TITLE
[FEAT] CommonExceptionHandler에서 queryParam 여부/타입에 대한 에러 메시지 분리

### DIFF
--- a/src/main/java/org/example/baba/exception/CustomExceptionHandler.java
+++ b/src/main/java/org/example/baba/exception/CustomExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -61,7 +62,16 @@ public class CustomExceptionHandler {
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   public ResponseEntity<String> handleMethodArgumentTypeMismatchException(
       MethodArgumentTypeMismatchException ex) {
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(INVALID_INPUT_VALUE.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(
+            INVALID_REQUEST_PARAM_TYPE.getMessage() + ": " + ex.getParameter().getParameterName());
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<String> handleMissingServletRequestParameterException(
+      MissingServletRequestParameterException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(NOT_NULL_REQUEST_PARAM.getMessage() + ": " + ex.getParameterName());
   }
 
   @ExceptionHandler(HttpMediaTypeNotSupportedException.class)

--- a/src/main/java/org/example/baba/exception/exceptionType/CommonExceptionType.java
+++ b/src/main/java/org/example/baba/exception/exceptionType/CommonExceptionType.java
@@ -13,7 +13,9 @@ public enum CommonExceptionType implements ExceptionType {
   NOT_FOUND_PATH(HttpStatus.NOT_FOUND, "요청하신 경로를 찾을 수 없습니다"),
 
   // 400 Bad Request
-  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다"),
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 값이 올바르지 않습니다"),
+  INVALID_REQUEST_PARAM_TYPE(HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 올바르지 않습니다"),
+  NOT_NULL_REQUEST_PARAM(HttpStatus.BAD_REQUEST, "필수 요청 파라미터 값을 입력해주세요"),
 
   // 415 UNSUPPORTED_MEDIA_TYPE
   INVALID_JSON_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "올바른 요청 형식이 아닙니다"),


### PR DESCRIPTION
## 📱 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #76 

## 📱 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 기존에 입력값이 올바르지 않습니다로 함께 처리했던 부분을 다음과 같이 3가지 케이스로 분리했습니다
```
  1. INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 값이 올바르지 않습니다")
  2. INVALID_REQUEST_PARAM_TYPE(HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 올바르지 않습니다")
  3. NOT_NULL_REQUEST_PARAM(HttpStatus.BAD_REQUEST, "필수 요청 파라미터 값을 입력해주세요")
```

## 📱 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📱 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
