### PR TITLE
[FEAT] 가입승인 메일 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,20 @@ spring:
     redis:
       host: localhost
       port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${smtpEmail}
+    password: ${smtpPassword}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          timeout: 20000
+          connectiontimeout: 20000
+          writetimeout: 20000
 jwt:
   prefix: 'Bearer '
   secret-key: ${JWT}


### PR DESCRIPTION
## 📱 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #78 
## 📱 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- [ ] build.gradle에 mail 의존성 추가
- [ ] application.yml 에 mail 설정 추가
- [ ] 가입승인 코드 전송 메소드에 실제 메일 전송 기능 구현
## 📱 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 메일 전송 성공시(postman)

![가입승인 메일 전송 응답](https://github.com/user-attachments/assets/601d8aaa-fcb7-41a3-bb8b-c5751b3803a1)

- 실제 메일 수신 내역

![가입승인 메일 전송](https://github.com/user-attachments/assets/dd7d9ae9-7e6f-4b5f-be19-3e9a689b5bd4)

## 📱 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
